### PR TITLE
Disable tmpfs for /tmp directory

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -119,9 +119,9 @@
   # Gaming optimizations
   boot.kernel.sysctl."vm.max_map_count" = 2147483642;
   
-  # Faster boot
+  # Clean tmp on boot (using disk instead of tmpfs for more space)
   boot.tmp.cleanOnBoot = true;
-  boot.tmp.useTmpfs = true;
+  boot.tmp.useTmpfs = false;
   
   # Set the system state version
   system.stateVersion = "25.05";


### PR DESCRIPTION
## Summary
- Disable tmpfs for `/tmp` directory by setting `boot.tmp.useTmpfs = false`
- Use disk storage instead of RAM for temporary files to provide more available space
- Maintain `boot.tmp.cleanOnBoot = true` to ensure cleanup on system restart

## Test plan
- [ ] Rebuild NixOS configuration and verify it applies successfully
- [ ] Check that `/tmp` is mounted on disk filesystem instead of tmpfs
- [ ] Test application behavior with larger temporary files to confirm increased space

🤖 Generated with [Claude Code](https://claude.ai/code)