### PR TITLE
Improve waybar cow module and sessionizer functionality

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,5 +1,9 @@
 { config, pkgs, ... }:
 
+let
+  vars = import ./variables.nix;
+in
+
 {
   imports = [
     # Your hardware-specific configuration
@@ -42,9 +46,9 @@
   console.keyMap = "us";
 
   # --- User Definition ---
-  users.users.vachicorne = {
+  users.users.${vars.username} = {
     isNormalUser = true;
-    description = "vachicorne";
+    description = "${vars.username}";
     extraGroups = [
       "networkmanager"
       "wheel"
@@ -121,7 +125,6 @@
   
   # Faster boot
   boot.tmp.cleanOnBoot = true;
-  boot.tmp.useTmpfs = true;
   
   # Set the system state version
   system.stateVersion = "25.05";

--- a/home.nix
+++ b/home.nix
@@ -30,8 +30,8 @@
   programs.fish.functions."sessionizer" = ''
     function sessionizer
         if test -z "$argv"
-            # Use fd for faster directory discovery and include deeper nesting in ~/Code
-            set -l selected_dir (fd . ~/Code ~/.config --type d --max-depth 2 --min-depth 1 | fzf)
+            # Find git repositories only
+            set -l selected_dir (fd . ~/Code ~/.config --type d --max-depth 2 --min-depth 1 -x test -d {}/.git | fzf)
         else
             set -l selected_dir $argv[1]
         end

--- a/hyprland/env.nix
+++ b/hyprland/env.nix
@@ -1,4 +1,8 @@
-{ ... }:
+{ config, ... }:
+
+let
+  vars = import ../variables.nix;
+in
 {
   wayland.windowManager.hyprland.settings = {
     env = [
@@ -20,6 +24,12 @@
       "TERMINAL,ghostty"
       "XDG_TERMINAL_EMULATOR,ghostty"
       "HYPRCURSOR_THEME,Bibata-Modern-Classic"
+      "DXVK_ENABLE_NVAPI,1"
+      "PROTON_ENABLE_NVAPI,1"
+      "__GL_SHADER_DISK_CACHE,1"
+      "__GL_SHADER_DISK_CACHE_SKIP_CLEANUP,1"
+      "__GL_SHADER_DISK_CACHE_SIZE,10737418240"
+      "__GL_SHADER_DISK_CACHE_PATH,${vars.userHome vars.username}/.shaders"
     ];
   };
 }

--- a/steam/default.nix
+++ b/steam/default.nix
@@ -9,6 +9,12 @@
       extraCompatPackages = with pkgs; [
         proton-ge-bin
       ];
+      extraPackages = with pkgs; [ mangohud ];
+      package = pkgs.steam.override {
+        extraEnv = {
+          MANGOHUD = "1";
+        };
+      };
     };
     gamescope = {
       enable = true;
@@ -29,12 +35,4 @@
     mangohud
   ];
 
-  environment.sessionVariables = {
-    DXVK_ENABLE_NVAPI = "1";
-    PROTON_ENABLE_NVAPI = "1";
-    __GL_SHADER_DISK_CACHE = "1";
-    __GL_SHADER_DISK_CACHE_SKIP_CLEANUP = "1";
-    __GL_SHADER_DISK_CACHE_SIZE = "10737418240";
-    MANGOHUD = "1";
-  };
 }

--- a/variables.nix
+++ b/variables.nix
@@ -1,0 +1,4 @@
+{
+  username = "vachicorne";
+  userHome = username: "/home/${username}";
+}

--- a/waybar/default.nix
+++ b/waybar/default.nix
@@ -12,6 +12,7 @@
       position = "top";
       height = 35;
       modules-left = [
+        "custom/cow"
         "hyprland/workspaces"
         "hyprland/mode"
       ];
@@ -22,11 +23,15 @@
         "cpu"
         "memory"
         "temperature"
+        "custom/gpu-temp"
         "clock"
         "tray"
       ];
 
       # --- Module Configurations ---
+      "custom/cow" = {
+        format = "󰆚 ";
+      };
 
       "hyprland/workspaces" = {
         format = "{name}";
@@ -92,6 +97,13 @@
         format-critical = " {temperatureC}°C";
         format = " {temperatureC}°C";
       };
+
+      "custom/gpu-temp" = {
+        exec = "nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits";
+        format = " {}°C";
+        interval = 2;
+        tooltip = false;
+      };
     };
   };
 
@@ -127,7 +139,7 @@
         background: #3c3836; /* Gruvbox lighter background */
     }
 
-    #clock, #pulseaudio, #network, #cpu, #memory, #temperature, #tray {
+    #clock, #pulseaudio, #network, #cpu, #memory, #temperature, #custom-gpu-temp, #tray {
         padding: 0 10px;
         margin: 0 4px;
         color: #ebdbb2;
@@ -135,6 +147,13 @@
 
     #window {
         font-weight: bold;
+    }
+
+    #custom-cow {
+        padding: 0 15px;
+        margin: 0 8px;
+        font-size: 18px;
+        color: #fe8019; /* Gruvbox light orange */
     }
   '';
 }


### PR DESCRIPTION
## Summary
- Fix waybar cow module typo and add Gruvbox orange styling with improved spacing
- Enhance sessionizer to only show git repositories for better project navigation
- Refactor MangoHUD configuration to only enable for Steam games instead of system-wide
- Add variables.nix for centralized configuration management

## Test plan
- [ ] Verify waybar cow module displays correctly with orange color
- [ ] Test sessionizer only shows git repositories
- [ ] Confirm MangoHUD only works with Steam games
- [ ] Check all configurations build without errors

🤖 Generated with [Claude Code](https://claude.ai/code)